### PR TITLE
Enabling plotting when NA present

### DIFF
--- a/pals/R/1DDiurnalCycle.R
+++ b/pals/R/1DDiurnalCycle.R
@@ -7,7 +7,8 @@
 # Gab Abramowitz CCRC, UNSW 2014 (palshelp at gmail dot com)
 #
 DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
-	timestepsize,whole,plotcolours,modlabel='no',vqcdata=matrix(-1,nrow=1,ncol=1)){
+	timestepsize,whole,plotcolours,modlabel='no',vqcdata=matrix(-1,nrow=1,ncol=1),
+  na.rm=FALSE){
 	errtext = 'ok'
 	metrics = list()
 	if(!whole){ # we need a whole number of years for this to run
@@ -27,6 +28,7 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 	par(mfcol=c(2,2),mar=c(4,4,3,0.5),oma=c(0,0,0,1),
 		mgp=c(2.5,0.7,0),ps=16,tcl=-0.4)
 	avday=array(0,dim=c(4,tstepinday,ncurves)) # initialise
+	perc_missing = matrix(0,4,ncurves) #initialise, % data missing each season and model/obs
 	if(modlabel=='no'){
 		alltitle=paste('Obs:',obslabel)
 	}else{
@@ -43,6 +45,8 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 		data_days = matrix(dcdata[,p],ncol=tstepinday,byrow=TRUE)
 		# A count of excluded values - zero if not using gap-filling info:
 		exclvals = matrix(0,4,tstepinday) # to count gap-filled data
+    #  A count of missing values for each season
+    missing_vals = matrix(0, ncol=4)
 		# First calculate values to be plotted:
 		for(k in 1:4){# for each season (DJF, MAM etc)
 			# Sum up variable over each year of data set for current season
@@ -59,16 +63,19 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 						# Allow NA value only if all years of season sum are NA:
 						if(l==1){ # 1st year of sum					
 							avday[k,i,p] = avday[k,i,p] + sum(thisyearsseason[
-								as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])])
+								as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])],na.rm=na.rm)
+              missing_vals[k] = missing_vals[k] + sum(is.na(thisyearsseason)) #count no. missing timesteps
 						}else{
 							if((!sumnotexist) & (!is.na(avday[k,i,p]))){ 
 								# i.e. sum exists and values for previous years exist
 								avday[k,i,p] = avday[k,i,p] + sum(thisyearsseason[
-									as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])])		
+									as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])],na.rm=na.rm)
+								missing_vals[k] = missing_vals[k] + sum(is.na(thisyearsseason)) #count no. missing timesteps
 							}else if(!sumnotexist){ 
 								# i.e. sum exists but previous years' sums are NA
 								avday[k,i,p] = sum(thisyearsseason[
-									as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])])
+									as.logical(qc_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])],na.rm=na.rm)
+								missing_vals[k] = missing_vals[k] + sum(is.na(thisyearsseason)) #count no. missing timesteps
 							}		
 						}
 					}
@@ -86,37 +93,45 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 							if((!sumnotexist) & (!is.na(avday[k,i,p]))){ 
 								# i.e. sum exists and values for previous years/DJF portions exist
 								avday[k,i,p] = avday[k,i,p] + sum(thisyearsseason[
-									as.logical(qc_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i])])		
+									as.logical(qc_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i])],na.rm=na.rm)
 							}else if(!sumnotexist){ 
 								# i.e. sum exists but previous years' sums are NA
 								avday[k,i,p] = sum(thisyearsseason[
-									as.logical(qc_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i])])
+									as.logical(qc_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i])],na.rm=na.rm)
 							}	
+							missing_vals[k] = missing_vals[k] + sum(is.na(thisyearsseason)) #count missing values
 						}
 					}
 				}else{ # no gap-filling information - assume all data are useable:
 					for(i in 1:tstepinday){
 						# Sum all values for each timestep:
 						avday[k,i,p]=avday[k,i,p] + 
-							sum(data_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])
+							sum(data_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i], na.rm=na.rm)
+						missing_vals[k] = missing_vals[k] + 
+              sum(is.na(data_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])) #count missing values
 					}
 					if(k==1){ # i.e. DJF, which is split in any year
 						# add Dec to Jan/Feb
 						for(i in 1:tstepinday){
 							avday[k,i,p]=avday[k,i,p] + 
-								sum(data_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i])
+								sum(data_days[(stid[k+4]+(l-1)*365):(fnid[k+4]+(l-1)*365),i], na.rm=na.rm)
+							missing_vals[k] = missing_vals[k] + 
+                sum(is.na(data_days[(stid[k]+(l-1)*365):(fnid[k]+(l-1)*365),i])) #count missing values
 						}
+            
 					}
 				} # use gap-filling info or not
 			} # for each year in the data set
 			
 			# Then find the average of these values:
 			if(k==1){ # i.e. DJF, which is split in any year
-				avday[k,,p]=avday[k,,p]/(90*nyears - exclvals[k,])
+				avday[k,,p]=avday[k,,p]/(90*nyears - exclvals[k,] - (missing_vals[k]/tstepinday))
 				removefrac[k] = sum(exclvals[k,])/(90*nyears*tstepinday)
+        perc_missing[k,p] <- missing_vals[k]/tstepinday/(90*nyears)*100
 			}else{
-				avday[k,,p]=avday[k,,p]/((fnid[k]-stid[k])*nyears - exclvals[k,])
+				avday[k,,p]=avday[k,,p]/((fnid[k]-stid[k])*nyears - exclvals[k,] - (missing_vals[k]/tstepinday))
 				removefrac[k] =  sum(exclvals[k,]) / ((fnid[k]-stid[k])*nyears*tstepinday)
+				perc_missing[k,p] <- missing_vals[k]/tstepinday/((fnid[k]-stid[k])*nyears)*100
 			}
 		} # over each season
 		if(p>1){
@@ -142,8 +157,8 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 	
 	# Determine boundaries for plots:
 	xloc=c(0:(tstepinday-1)) # set location of x-coords in plot
-	yaxmin=min(avday) # y axis minimum in plot
-	yaxmax=max(avday)+(max(avday)-yaxmin)*0.15 # y axis maximum in plot
+	yaxmin=min(avday,na.rm=na.rm) # y axis minimum in plot
+	yaxmax=max(avday,na.rm=na.rm)+(max(avday,na.rm=na.rm)-yaxmin)*0.15 # y axis maximum in plot
 	# Now plot each panel:
 	for(k in 1:4){# for each season (DJF, MAM etc)
 		# Plot obs data result:
@@ -214,6 +229,14 @@ DiurnalCycle = function(obslabel,dcdata,varname,ytext,legendtext,
 			scoretext = paste('Score: ',scorestring,'\n','(NME; ',
 				removestring,'% data removed)',sep='')
 			text((tstepinday/2),yaxmax-(yaxmax-yaxmin)*0.07,scoretext,pos=4)	
+		}
+		#Print percentage of data missing if na.rm=TRUE and some data missing
+		if(na.rm){
+		  if(any(perc_missing[k,] > 0)){
+        rounded=round(perc_missing[k,],digits=3)
+		    text(-1,yaxmax,paste("(",paste(rounded,collapse=", "), ")% data missing", sep=""),
+             pos=4, col="red")
+		  }
 		}
 	} # each plot / season
 	result=list(err=FALSE,errtext=errtext,metrics=metrics)

--- a/pals/R/1DTimeseries.R
+++ b/pals/R/1DTimeseries.R
@@ -6,7 +6,7 @@
 
 Timeseries = function(obslabel,tsdata,varname,ytext,legendtext,
                       plotcex,timing,smoothed=FALSE,winsize=1,plotcolours,modlabel='no',
-                      vqcdata=matrix(-1,nrow=1,ncol=1)){
+                      vqcdata=matrix(-1,nrow=1,ncol=1),na.rm=FALSE){
   #
   errtext = 'ok'
   metrics = list()
@@ -25,26 +25,33 @@ Timeseries = function(obslabel,tsdata,varname,ytext,legendtext,
       data_days=matrix(tsdata[,p],ncol=tstepinday,byrow=TRUE) 
       for(i in 1:(ndays-winsize-1)){
         # Find evaporative fraction using averaging window:
-        data_smooth[i,p] = mean(data_days[i:(i+winsize-1),])
+        data_smooth[i,p] = mean(data_days[i:(i+winsize-1),],na.rm=na.rm)
       }
       if(p==1){
-        yvalmin = as.character(signif(min(tsdata[,p]),3))
-        yvalmax = as.character(signif(max(tsdata[,p]),3))
-        datamean = as.character(signif(mean(tsdata[,p]),3))
-        datasd = as.character(signif(sd(tsdata[,p]),3))
+        yvalmin = as.character(signif(min(tsdata[,p],na.rm=na.rm),3))
+        yvalmax = as.character(signif(max(tsdata[,p],na.rm=na.rm),3))
+        datamean = as.character(signif(mean(tsdata[,p],na.rm=na.rm),3))
+        datasd = as.character(signif(sd(tsdata[,p],na.rm=na.rm),3))
         
       }else{
-        yvalmin = paste(yvalmin,', ',as.character(signif(min(tsdata[,p]),3)),sep='')
-        yvalmax = paste(yvalmax,', ',as.character(signif(max(tsdata[,p]),3)),sep='')
-        datamean = paste(datamean,', ',as.character(signif(mean(tsdata[,p]),3)),sep='')
-        datasd = paste(datasd,', ',as.character(signif(sd(tsdata[,p]),3)),sep='')
+        yvalmin = paste(yvalmin,', ',as.character(signif(min(tsdata[,p],na.rm=na.rm),3)),sep='')
+        yvalmax = paste(yvalmax,', ',as.character(signif(max(tsdata[,p],na.rm=na.rm),3)),sep='')
+        datamean = paste(datamean,', ',as.character(signif(mean(tsdata[,p],na.rm=na.rm),3)),sep='')
+        datasd = paste(datasd,', ',as.character(signif(sd(tsdata[,p]),3),na.rm=na.rm),sep='')
       }
     }
-    ymin = signif(min(data_smooth),3)
-    ymax = signif(max(data_smooth),3)
+    ymin = signif(min(data_smooth,na.rm=na.rm),3)
+    ymax = signif(max(data_smooth,na.rm=na.rm),3)
     # If we're adding a gap-filling QC line, make space for it:
     if(vqcdata[1,1] != -1) {
       ymin = ymin - (ymax-ymin)*0.06
+    }
+    #If ignoring NA, make space for printing % missing
+    #Also shift other labels and legend down in this case
+    y_adj=1
+    if(na.rm){
+      ymax=ymax*1.1
+      y_adj = 0.94
     }
     xmin = 1
     xmax = length(data_smooth[,1])
@@ -102,7 +109,7 @@ Timeseries = function(obslabel,tsdata,varname,ytext,legendtext,
       xxlab[(2*l)]=paste('1 Jun',substr(as.character(timing$syear+l-1),3,4))
     }
     # place legend:
-    legend(xmin-(xmax-xmin)*0.03,(ymin + (ymax-ymin)*1.24),legend=legendtext[1:ncurves],lty=1,
+    legend(xmin-(xmax-xmin)*0.03,(ymin + (ymax-ymin)*(y_adj+0.24)),legend=legendtext[1:ncurves],lty=1,
            col=plotcolours[1:ncurves],lwd=3,bty="n",cex=max((plotcex*0.75),1))
     # Add title:
     if(modlabel=='no'){
@@ -113,23 +120,33 @@ Timeseries = function(obslabel,tsdata,varname,ytext,legendtext,
                   obslabel,'   Model - ',modlabel,sep=''),cex.main=plotcex)
     }
     # Add Max/Min/Mean/SD numbers:
-    text(x=(xmin+(xmax-xmin)*0.25),y=c(ymin + (ymax-ymin)*1.19,ymin + (ymax-ymin)*1.14),
+    text(x=(xmin+(xmax-xmin)*0.25),y=c(ymin + (ymax-ymin)*(y_adj+0.19),ymin + (ymax-ymin)*(y_adj+0.14)),
          labels=c(paste('Min = (',yvalmin,')',sep=''),
                   paste('Max = (',yvalmax,')',sep='')),
          cex=max((plotcex*0.75),1),pos=4)
-    text(x=(xmin+(xmax-xmin)*0.25),y=c(ymin + (ymax-ymin)*1.09,ymin + (ymax-ymin)*1.04),
+    text(x=(xmin+(xmax-xmin)*0.25),y=c(ymin + (ymax-ymin)*(y_adj+0.09),ymin + (ymax-ymin)*(y_adj+0.04)),
          labels=c(paste('Mean = (',datamean,')',sep=''),paste('SD = (',datasd,')',sep='')),
          cex=max((plotcex*0.75),1),pos=4)
     # Add NME scores to plot (if there is at least one model output):
     if(ncurves>1){
       sscorestring = paste(signif(smoothscore,digits=3),collapse=', ')
       ascorestring = paste(signif(allscore,digits=3),collapse=', ')
-      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*1.18),
+      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*(y_adj+0.18)),
            labels=paste('Score_smooth: ',sscorestring,sep=''),,pos=4)
-      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*1.12),
+      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*(y_adj+0.12)),
            labels= paste('Score_all: ',ascorestring,sep=''),pos=4)
-      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*1.06),
+      text(x=c(xmin+(xmax-xmin)*0.65),y=(ymin + (ymax-ymin)*(y_adj+0.06)),
            labels=' (NME)',pos=4)
+    }
+    #Print percentage of data missing if na.rm=TRUE and some data missing
+    if(na.rm){
+      perc_missing = round(sapply(1:ncol(tsdata), function(x) 
+        sum(is.na(tsdata[,x]))/length(tsdata[,x])), digits=3)      
+      if(any(perc_missing > 0)){
+        text(xmin-(xmax-xmin)*0.03,y=(ymin + (ymax-ymin)*(y_adj+0.24)),
+             paste("(",paste(perc_missing,collapse=", "), ")% data missing", sep=""),
+             pos=4,offset=1, col="red")
+      }
     }
     # Calculate QC time series information, if it exists:
     if(vqcdata[1,1] != -1){


### PR DESCRIPTION
Added option to ignore NA values when plotting 1DAnnualCycle, 1DDiurnalCycle and 1DTimeseries plots.

These codes now ignore NA values when calculating plotting data, when na.rm is set to TRUE. If any data is missing, the percentage of missing data is printed to the figure.

Apart from adding na.rm arguments, these changes were necessary to each file:

**1DAnnualCycle**
New variable "days_missing" was added to calculate the number of missing daily averages. This is used to average with the correct number of days on line 52 (number of non-missing days as opposed to total number of days).

**1DDiurnalCycle**
As above, need to calculate the number of missing time steps ("missing_vals") to average with the correct number of days on lines 128 and 132. "Missing_vals" is divided by "tstepinday" to convert it from the number of missing time steps to missing days.

**1DTimeseries**
Added a "y_adj" parameter for plotting. This shifts the legend and other labels down when na.rm=TRUE to create space for printing % missing on top of figure.